### PR TITLE
Fixed CacheService checking if `$adapterStack` is null.

### DIFF
--- a/src/CacheService.php
+++ b/src/CacheService.php
@@ -83,7 +83,7 @@ class CacheService
      */
     public function getAdapterStack(): array
     {
-        if ($this->adapterStack === null) {
+        if (empty($this->adapterStack)) {
             $this->createAdapterStack($this->cacheConfig);
         }
 


### PR DESCRIPTION
When this library was upgraded to PHP 7, `$adapterStack` was changed to default to an empty array. Because of this, the null check would never return true.
