### PR TITLE
Special Characters in Aerospike Set Name

### DIFF
--- a/src/Adapter/AerospikeAdapter.php
+++ b/src/Adapter/AerospikeAdapter.php
@@ -167,7 +167,7 @@ class AerospikeAdapter extends AbstractAdapter implements AdapterInterface
 
     protected function getNamespacedKey(string $key)
     {
-        return $this->db->initKey($this->aerospikeNamespace, $this->namespace, $key);
+        return $this->db->initKey($this->aerospikeNamespace, str_replace($this->namespace, [':', '.'], '_'), $key);
     }
 
     protected function createBin($value): array


### PR DESCRIPTION
Substituted special chars : and . for underscores due to the inability of the Aerospike client (AQL) to parse with these special characters in the set name.