### PR TITLE
Fixed str_replace function call

### DIFF
--- a/src/Adapter/AerospikeAdapter.php
+++ b/src/Adapter/AerospikeAdapter.php
@@ -167,7 +167,7 @@ class AerospikeAdapter extends AbstractAdapter implements AdapterInterface
 
     protected function getNamespacedKey(string $key)
     {
-        return $this->db->initKey($this->aerospikeNamespace, str_replace($this->namespace, [':', '.'], '_'), $key);
+        return $this->db->initKey($this->aerospikeNamespace, str_replace([':', '.'], '_', $this->namespace), $key);
     }
 
     protected function createBin($value): array


### PR DESCRIPTION
Fixed the parameter order for the *str_replace* function call in the Aerospike adapter.