### PR TITLE
refactor: remove Inflector deprecation

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,8 +4,6 @@ parameters:
     paths:
         - src
     ignoreErrors:
-        - '#Method Redis\:\:connect\(\) invoked with 5 parameters\, 1\-4 required#'
-
         # Failed to detect magic method in Predis\Client
         - '#Call to an undefined method Predis\\Client\:\:flushAll\(\)#'
 

--- a/src/CacheService.php
+++ b/src/CacheService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Cache;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Linio\Component\Cache\Adapter\AdapterInterface;
 use Linio\Component\Cache\Encoder\EncoderInterface;
 use Linio\Component\Cache\Exception\InvalidConfigurationException;
@@ -276,7 +276,8 @@ class CacheService
         foreach ($cacheConfig['layers'] as $adapterConfig) {
             $this->validateAdapterConfig($adapterConfig);
 
-            $adapterClass = sprintf('%s\\Adapter\\%sAdapter', __NAMESPACE__, Inflector::classify($adapterConfig['adapter_name']));
+            $inflector = InflectorFactory::create()->build();
+            $adapterClass = sprintf('%s\\Adapter\\%sAdapter', __NAMESPACE__, $inflector->classify($adapterConfig['adapter_name']));
 
             if (!class_exists($adapterClass)) {
                 throw new InvalidConfigurationException('Adapter class does not exist: ' . $adapterClass);
@@ -295,7 +296,8 @@ class CacheService
      */
     protected function createEncoder(string $encoderName): void
     {
-        $encoderClass = sprintf('%s\\Encoder\\%sEncoder', __NAMESPACE__, Inflector::classify($encoderName));
+        $inflector = InflectorFactory::create()->build();
+        $encoderClass = sprintf('%s\\Encoder\\%sEncoder', __NAMESPACE__, $inflector->classify($encoderName));
 
         if (!class_exists($encoderClass)) {
             throw new InvalidConfigurationException('Encoder class does not exist: ' . $encoderClass);


### PR DESCRIPTION
**Goal**
Remove the User Deprecated: The "Doctrine\Common\Inflector\Inflector::classify" method is deprecated and will be dropped in doctrine/inflector 2.0.
