### PR TITLE
test: remove deprecations and code style

### DIFF
--- a/src/Adapter/MysqlAdapter.php
+++ b/src/Adapter/MysqlAdapter.php
@@ -42,8 +42,9 @@ class MysqlAdapter extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-     * @return mixed
      * @throws KeyNotFoundException when the key does not exist
+     *
+     * @return mixed
      */
     public function get(string $key)
     {

--- a/src/Adapter/MysqlAdapter.php
+++ b/src/Adapter/MysqlAdapter.php
@@ -43,6 +43,7 @@ class MysqlAdapter extends AbstractAdapter implements AdapterInterface
 
     /**
      * @return mixed
+     * @throws KeyNotFoundException when the key does not exist
      */
     public function get(string $key)
     {

--- a/tests/Adapter/ApcAdapterTest.php
+++ b/tests/Adapter/ApcAdapterTest.php
@@ -15,7 +15,7 @@ class ApcAdapterTest extends TestCase
     {
         $this->adapter = $this->getMockBuilder(ApcAdapter::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
+            ->onlyMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();
         $this->adapter->setNamespace('mx');
     }

--- a/tests/Adapter/ApcAdapterTest.php
+++ b/tests/Adapter/ApcAdapterTest.php
@@ -13,7 +13,7 @@ class ApcAdapterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->adapter = $this->getMockBuilder('Linio\Component\Cache\Adapter\ApcAdapter')
+        $this->adapter = $this->getMockBuilder(ApcAdapter::class)
             ->disableOriginalConstructor()
             ->setMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();

--- a/tests/Adapter/ApcuAdapterTest.php
+++ b/tests/Adapter/ApcuAdapterTest.php
@@ -15,7 +15,7 @@ class ApcuAdapterTest extends TestCase
     {
         $this->adapter = $this->getMockBuilder(ApcuAdapter::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
+            ->onlyMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();
         $this->adapter->setNamespace('mx');
     }

--- a/tests/Adapter/ApcuAdapterTest.php
+++ b/tests/Adapter/ApcuAdapterTest.php
@@ -13,7 +13,7 @@ class ApcuAdapterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->adapter = $this->getMockBuilder('Linio\Component\Cache\Adapter\ApcuAdapter')
+        $this->adapter = $this->getMockBuilder(ApcuAdapter::class)
             ->disableOriginalConstructor()
             ->setMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();

--- a/tests/Adapter/ArrayAdapterTest.php
+++ b/tests/Adapter/ArrayAdapterTest.php
@@ -30,7 +30,7 @@ class ArrayAdapterTest extends TestCase
         $adapter = new ArrayAdapter();
         $adapter->setNamespace(static::TEST_NAMESPACE);
 
-        $actual = $adapter->get('foo');
+        $adapter->get('foo');
     }
 
     public function testIsFindingKey(): void
@@ -99,7 +99,6 @@ class ArrayAdapterTest extends TestCase
 
         $deleteResult = $adapter->delete('foo');
 
-        $actual = 'bar';
         try {
             $actual = $adapter->get('foo');
         } catch (KeyNotFoundException $e) {
@@ -157,14 +156,12 @@ class ArrayAdapterTest extends TestCase
 
         $deleteResult = $adapter->deleteMulti(['foo', 'nop']);
 
-        $actual1 = 'bar';
         try {
             $actual1 = $adapter->get('foo');
         } catch (KeyNotFoundException $e) {
             $actual1 = null;
         }
 
-        $actual2 = 'baz';
         try {
             $actual2 = $adapter->get('fooz');
         } catch (KeyNotFoundException $e) {
@@ -185,14 +182,12 @@ class ArrayAdapterTest extends TestCase
 
         $flushResult = $adapter->flush();
 
-        $actual1 = 'bar';
         try {
             $actual1 = $adapter->get('foo');
         } catch (KeyNotFoundException $e) {
             $actual1 = null;
         }
 
-        $actual2 = 'baz';
         try {
             $actual2 = $adapter->get('fooz');
         } catch (KeyNotFoundException $e) {

--- a/tests/Adapter/ArrayAdapterTest.php
+++ b/tests/Adapter/ArrayAdapterTest.php
@@ -25,7 +25,7 @@ class ArrayAdapterTest extends TestCase
 
     public function testIsGettingNonexistentKey(): void
     {
-        $this->expectException(\Linio\Component\Cache\Exception\KeyNotFoundException::class);
+        $this->expectException(KeyNotFoundException::class);
 
         $adapter = new ArrayAdapter();
         $adapter->setNamespace(static::TEST_NAMESPACE);

--- a/tests/Adapter/MemcachedAdapterPersistentTest.php
+++ b/tests/Adapter/MemcachedAdapterPersistentTest.php
@@ -15,7 +15,7 @@ class MemcachedAdapterPersistentTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->adapter = $this->getMockBuilder('Linio\Component\Cache\Adapter\MemcachedAdapter')
+        $this->adapter = $this->getMockBuilder(MemcachedAdapter::class)
             ->disableOriginalConstructor()
             ->setMethods(['setNamespace', 'flush', 'set', 'get', 'delete', 'contains', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();

--- a/tests/Adapter/MemcachedAdapterPersistentTest.php
+++ b/tests/Adapter/MemcachedAdapterPersistentTest.php
@@ -17,7 +17,7 @@ class MemcachedAdapterPersistentTest extends TestCase
     {
         $this->adapter = $this->getMockBuilder(MemcachedAdapter::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setNamespace', 'flush', 'set', 'get', 'delete', 'contains', 'getMulti', 'setMulti', 'deleteMulti'])
+            ->onlyMethods(['setNamespace', 'flush', 'set', 'get', 'delete', 'contains', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();
         $this->adapter->setNamespace('mx');
 

--- a/tests/Adapter/MemcachedAdapterTest.php
+++ b/tests/Adapter/MemcachedAdapterTest.php
@@ -16,7 +16,7 @@ class MemcachedAdapterTest extends TestCase
     {
         $this->adapter = $this->getMockBuilder(MemcachedAdapter::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setNamespace', 'flush', 'set', 'get', 'delete', 'contains', 'getMulti', 'setMulti', 'deleteMulti'])
+            ->onlyMethods(['setNamespace', 'flush', 'set', 'get', 'delete', 'contains', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();
         $this->adapter->setNamespace('mx');
 

--- a/tests/Adapter/MemcachedAdapterTest.php
+++ b/tests/Adapter/MemcachedAdapterTest.php
@@ -14,7 +14,7 @@ class MemcachedAdapterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->adapter = $this->getMockBuilder('Linio\Component\Cache\Adapter\MemcachedAdapter')
+        $this->adapter = $this->getMockBuilder(MemcachedAdapter::class)
             ->disableOriginalConstructor()
             ->setMethods(['setNamespace', 'flush', 'set', 'get', 'delete', 'contains', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();

--- a/tests/Adapter/MysqlAdapterTest.php
+++ b/tests/Adapter/MysqlAdapterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Linio\Component\Cache\Adapter;
 
 use Linio\Component\Cache\Exception\InvalidConfigurationException;
+use Linio\Component\Cache\Exception\KeyNotFoundException;
 use Linio\Component\Database\DatabaseManager;
 use PHPUnit\Framework\TestCase;
 
@@ -19,7 +20,7 @@ class MysqlAdapterTest extends TestCase
     {
         $this->adapter = $this->getMockBuilder(MysqlAdapter::class)
             ->disableOriginalConstructor()
-            ->setMethods(null)
+            ->onlyMethods([])
             ->getMock();
         $this->adapter->setNamespace(static::TEST_NAMESPACE);
     }
@@ -133,7 +134,7 @@ class MysqlAdapterTest extends TestCase
 
     public function testIsGettingNonexistentKey(): void
     {
-        $this->expectException(\Linio\Component\Cache\Exception\KeyNotFoundException::class);
+        $this->expectException(KeyNotFoundException::class);
 
         $expectedQuery = sprintf('SELECT `value` FROM `%s` WHERE `key` = :key LIMIT 1', self::TABLE_NAME);
 
@@ -145,7 +146,7 @@ class MysqlAdapterTest extends TestCase
         $this->adapter->setDbManager($mockDb);
         $this->adapter->setTableName(self::TABLE_NAME);
 
-        $actual = $this->adapter->get('foo');
+        $this->adapter->get('foo');
     }
 
     public function testIsFindingKey(): void

--- a/tests/Adapter/MysqlAdapterTest.php
+++ b/tests/Adapter/MysqlAdapterTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Linio\Component\Cache\Adapter;
 
+use Linio\Component\Cache\Exception\InvalidConfigurationException;
+use Linio\Component\Database\DatabaseManager;
 use PHPUnit\Framework\TestCase;
 
 class MysqlAdapterTest extends TestCase
@@ -15,7 +17,7 @@ class MysqlAdapterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->adapter = $this->getMockBuilder('Linio\Component\Cache\Adapter\MysqlAdapter')
+        $this->adapter = $this->getMockBuilder(MysqlAdapter::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
@@ -24,7 +26,7 @@ class MysqlAdapterTest extends TestCase
 
     public function testIsValidatingConstructorParameterHost(): void
     {
-        $this->expectException(\Linio\Component\Cache\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $adapter = new MysqlAdapter(
             [
@@ -39,7 +41,7 @@ class MysqlAdapterTest extends TestCase
 
     public function testIsValidatingConstructorParameterPort(): void
     {
-        $this->expectException(\Linio\Component\Cache\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $adapter = new MysqlAdapter(
             [
@@ -54,7 +56,7 @@ class MysqlAdapterTest extends TestCase
 
     public function testIsValidatingConstructorParameterDbname(): void
     {
-        $this->expectException(\Linio\Component\Cache\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $adapter = new MysqlAdapter(
             [
@@ -69,7 +71,7 @@ class MysqlAdapterTest extends TestCase
 
     public function testIsValidatingConstructorParameterUsername(): void
     {
-        $this->expectException(\Linio\Component\Cache\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $adapter = new MysqlAdapter(
             [
@@ -84,7 +86,7 @@ class MysqlAdapterTest extends TestCase
 
     public function testIsValidatingConstructorParameterPassword(): void
     {
-        $this->expectException(\Linio\Component\Cache\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $adapter = new MysqlAdapter(
             [
@@ -99,7 +101,7 @@ class MysqlAdapterTest extends TestCase
 
     public function testIsValidatingConstructorParameterTableName(): void
     {
-        $this->expectException(\Linio\Component\Cache\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $adapter = new MysqlAdapter(
             [
@@ -116,7 +118,7 @@ class MysqlAdapterTest extends TestCase
     {
         $expectedQuery = sprintf('SELECT `value` FROM `%s` WHERE `key` = :key LIMIT 1', self::TABLE_NAME);
 
-        $mockDb = $this->createMock('Linio\Component\Database\DatabaseManager');
+        $mockDb = $this->createMock(DatabaseManager::class);
         $mockDb->expects($this->once())
             ->method('fetchColumn')
             ->with($this->equalTo($expectedQuery), $this->equalTo(['key' => static::TEST_NAMESPACE . ':foo']), 0)
@@ -135,7 +137,7 @@ class MysqlAdapterTest extends TestCase
 
         $expectedQuery = sprintf('SELECT `value` FROM `%s` WHERE `key` = :key LIMIT 1', self::TABLE_NAME);
 
-        $mockDb = $this->createMock('Linio\Component\Database\DatabaseManager');
+        $mockDb = $this->createMock(DatabaseManager::class);
         $mockDb->expects($this->once())
             ->method('fetchColumn')
             ->with($this->equalTo($expectedQuery), $this->equalTo(['key' => static::TEST_NAMESPACE . ':foo']), 0)
@@ -150,7 +152,7 @@ class MysqlAdapterTest extends TestCase
     {
         $expectedQuery = sprintf('SELECT `value` FROM `%s` WHERE `key` = :key LIMIT 1', self::TABLE_NAME);
 
-        $mockDb = $this->createMock('Linio\Component\Database\DatabaseManager');
+        $mockDb = $this->createMock(DatabaseManager::class);
         $mockDb->expects($this->once())
             ->method('fetchColumn')
             ->with($this->equalTo($expectedQuery), $this->equalTo(['key' => static::TEST_NAMESPACE . ':foo']), 0)
@@ -167,7 +169,7 @@ class MysqlAdapterTest extends TestCase
     {
         $expectedQuery = sprintf('SELECT `value` FROM `%s` WHERE `key` = :key LIMIT 1', self::TABLE_NAME);
 
-        $mockDb = $this->createMock('Linio\Component\Database\DatabaseManager');
+        $mockDb = $this->createMock(DatabaseManager::class);
         $mockDb->expects($this->once())
             ->method('fetchColumn')
             ->with($this->equalTo($expectedQuery), $this->equalTo(['key' => static::TEST_NAMESPACE . ':baz']), 0)
@@ -184,7 +186,7 @@ class MysqlAdapterTest extends TestCase
     {
         $expectedQuery = sprintf('SELECT `key`, `value` FROM `%s` WHERE `key` IN(?,?)', self::TABLE_NAME);
 
-        $mockDb = $this->createMock('Linio\Component\Database\DatabaseManager');
+        $mockDb = $this->createMock(DatabaseManager::class);
         $mockDb->expects($this->once())
             ->method('fetchKeyPairs')
             ->with($this->equalTo($expectedQuery), $this->equalTo([static::TEST_NAMESPACE . ':foo', static::TEST_NAMESPACE . ':fooz']))
@@ -201,7 +203,7 @@ class MysqlAdapterTest extends TestCase
     {
         $expectedQuery = sprintf('SELECT `key`, `value` FROM `%s` WHERE `key` IN(?,?)', self::TABLE_NAME);
 
-        $mockDb = $this->createMock('Linio\Component\Database\DatabaseManager');
+        $mockDb = $this->createMock(DatabaseManager::class);
         $mockDb->expects($this->once())
             ->method('fetchKeyPairs')
             ->with($this->equalTo($expectedQuery), $this->equalTo([static::TEST_NAMESPACE . ':foo', static::TEST_NAMESPACE . ':nop']))
@@ -218,7 +220,7 @@ class MysqlAdapterTest extends TestCase
     {
         $expectedQuery = sprintf('INSERT INTO `%s` (`key`, `value`) VALUES(:key, :value) ON DUPLICATE KEY UPDATE `value` = VALUES(`value`)', self::TABLE_NAME);
 
-        $mockDb = $this->createMock('Linio\Component\Database\DatabaseManager');
+        $mockDb = $this->createMock(DatabaseManager::class);
         $mockDb->expects($this->once())
             ->method('execute')
             ->with($this->equalTo($expectedQuery), $this->equalTo(['key' => static::TEST_NAMESPACE . ':foo', 'value' => 'bar']))
@@ -235,7 +237,7 @@ class MysqlAdapterTest extends TestCase
     {
         $expectedQuery = sprintf('INSERT INTO `%s` (`key`, `value`) VALUES (?, ?),(?, ?) ON DUPLICATE KEY UPDATE `value` = VALUES(`value`)', self::TABLE_NAME);
 
-        $mockDb = $this->createMock('Linio\Component\Database\DatabaseManager');
+        $mockDb = $this->createMock(DatabaseManager::class);
         $mockDb->expects($this->once())
             ->method('execute')
             ->with($this->equalTo($expectedQuery), $this->equalTo([static::TEST_NAMESPACE . ':foo', 'bar', static::TEST_NAMESPACE . ':fooz', 'baz']))
@@ -252,7 +254,7 @@ class MysqlAdapterTest extends TestCase
     {
         $expectedQuery = sprintf('DELETE FROM `%s` WHERE `key` = :key', self::TABLE_NAME);
 
-        $mockDb = $this->createMock('Linio\Component\Database\DatabaseManager');
+        $mockDb = $this->createMock(DatabaseManager::class);
         $mockDb->expects($this->once())
             ->method('execute')
             ->with($this->equalTo($expectedQuery), $this->equalTo(['key' => static::TEST_NAMESPACE . ':foo']))
@@ -269,7 +271,7 @@ class MysqlAdapterTest extends TestCase
     {
         $expectedQuery = sprintf('DELETE FROM `%s` WHERE `key` IN (?,?)', self::TABLE_NAME);
 
-        $mockDb = $this->createMock('Linio\Component\Database\DatabaseManager');
+        $mockDb = $this->createMock(DatabaseManager::class);
         $mockDb->expects($this->once())
             ->method('execute')
             ->with($this->equalTo($expectedQuery), $this->equalTo([static::TEST_NAMESPACE . ':foo', static::TEST_NAMESPACE . ':fooz']))
@@ -286,7 +288,7 @@ class MysqlAdapterTest extends TestCase
     {
         $expectedQuery = sprintf('DELETE FROM `%s` WHERE `key` = :key', self::TABLE_NAME);
 
-        $mockDb = $this->createMock('Linio\Component\Database\DatabaseManager');
+        $mockDb = $this->createMock(DatabaseManager::class);
         $mockDb->expects($this->once())
             ->method('execute')
             ->with($this->equalTo($expectedQuery), $this->equalTo(['key' => static::TEST_NAMESPACE . ':nop']))
@@ -303,7 +305,7 @@ class MysqlAdapterTest extends TestCase
     {
         $expectedQuery = sprintf('DELETE FROM `%s` WHERE `key` IN (?,?)', self::TABLE_NAME);
 
-        $mockDb = $this->createMock('Linio\Component\Database\DatabaseManager');
+        $mockDb = $this->createMock(DatabaseManager::class);
         $mockDb->expects($this->once())
             ->method('execute')
             ->with($this->equalTo($expectedQuery), $this->equalTo([static::TEST_NAMESPACE . ':foo', static::TEST_NAMESPACE . ':nop']))
@@ -320,7 +322,7 @@ class MysqlAdapterTest extends TestCase
     {
         $expectedQuery = sprintf('DELETE FROM `%s`', self::TABLE_NAME);
 
-        $mockDb = $this->createMock('Linio\Component\Database\DatabaseManager');
+        $mockDb = $this->createMock(DatabaseManager::class);
         $mockDb->expects($this->once())
             ->method('execute')
             ->with($this->equalTo($expectedQuery))

--- a/tests/Adapter/PhpredisAdapterIgbinarySerializerTest.php
+++ b/tests/Adapter/PhpredisAdapterIgbinarySerializerTest.php
@@ -16,7 +16,7 @@ class PhpredisAdapterIgbinarySerializerTest extends TestCase
     {
         $this->adapter = $this->getMockBuilder(PhpredisAdapter::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
+            ->onlyMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();
         $this->adapter->setNamespace('mx');
     }

--- a/tests/Adapter/PhpredisAdapterIgbinarySerializerTest.php
+++ b/tests/Adapter/PhpredisAdapterIgbinarySerializerTest.php
@@ -14,7 +14,7 @@ class PhpredisAdapterIgbinarySerializerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->adapter = $this->getMockBuilder('Linio\Component\Cache\Adapter\PhpredisAdapter')
+        $this->adapter = $this->getMockBuilder(PhpredisAdapter::class)
             ->disableOriginalConstructor()
             ->setMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();

--- a/tests/Adapter/PhpredisAdapterPersistentTest.php
+++ b/tests/Adapter/PhpredisAdapterPersistentTest.php
@@ -17,7 +17,7 @@ class PhpredisAdapterPersistentTest extends TestCase
     {
         $this->adapter = $this->getMockBuilder(PhpredisAdapter::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
+            ->onlyMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();
         $this->adapter->setNamespace('mx');
     }

--- a/tests/Adapter/PhpredisAdapterPersistentTest.php
+++ b/tests/Adapter/PhpredisAdapterPersistentTest.php
@@ -60,18 +60,20 @@ class PhpredisAdapterPersistentTest extends TestCase
             $this->markTestSkipped('Using thread safe version. Persistent connection is not supported when thread safe is enabled.');
         }
 
-        $connections = [];
-        for ($i = 1; $i <= 100; $i++) {
+        $connectionList = [];
+        for ($i = 1; $i <= 10; $i++) {
             $connection = new PhpredisAdapter(['connection_persistent' => true, 'pool_size' => 10], false);
-            $connections[] = $connection;
+            $connectionList[] = $connection;
         }
 
-        $client100 = Assert::readAttribute($connection, 'client');
-        /** @var $client100 \Redis */
-        $info = $client100->info();
-        $connectedClients = $info['connected_clients'];
+        foreach ($connectionList as $connection) {
+            $client100 = Assert::readAttribute($connection, 'client');
+            /** @var $client100 \Redis */
+            $info = $client100->info();
+            $connectedClients = $info['connected_clients'];
 
-        $this->assertEquals(10, $connectedClients);
+            $this->assertEquals(10, $connectedClients);
+        }
     }
 
     public function testIsSettingAndGetting(): void

--- a/tests/Adapter/PhpredisAdapterPersistentTest.php
+++ b/tests/Adapter/PhpredisAdapterPersistentTest.php
@@ -15,7 +15,7 @@ class PhpredisAdapterPersistentTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->adapter = $this->getMockBuilder('Linio\Component\Cache\Adapter\PhpredisAdapter')
+        $this->adapter = $this->getMockBuilder(PhpredisAdapter::class)
             ->disableOriginalConstructor()
             ->setMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();

--- a/tests/Adapter/PhpredisAdapterPhpSerializerTest.php
+++ b/tests/Adapter/PhpredisAdapterPhpSerializerTest.php
@@ -14,7 +14,7 @@ class PhpredisAdapterPhpSerializerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->adapter = $this->getMockBuilder('Linio\Component\Cache\Adapter\PhpredisAdapter')
+        $this->adapter = $this->getMockBuilder(PhpredisAdapter::class)
             ->disableOriginalConstructor()
             ->setMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();

--- a/tests/Adapter/PhpredisAdapterPhpSerializerTest.php
+++ b/tests/Adapter/PhpredisAdapterPhpSerializerTest.php
@@ -16,7 +16,7 @@ class PhpredisAdapterPhpSerializerTest extends TestCase
     {
         $this->adapter = $this->getMockBuilder(PhpredisAdapter::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
+            ->onlyMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();
         $this->adapter->setNamespace('mx');
     }

--- a/tests/Adapter/PhpredisAdapterTest.php
+++ b/tests/Adapter/PhpredisAdapterTest.php
@@ -15,7 +15,7 @@ class PhpredisAdapterTest extends TestCase
     {
         $this->adapter = $this->getMockBuilder(PhpredisAdapter::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
+            ->onlyMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();
         $this->adapter->setNamespace('mx');
     }

--- a/tests/Adapter/PhpredisAdapterTest.php
+++ b/tests/Adapter/PhpredisAdapterTest.php
@@ -13,7 +13,7 @@ class PhpredisAdapterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->adapter = $this->getMockBuilder('Linio\Component\Cache\Adapter\PhpredisAdapter')
+        $this->adapter = $this->getMockBuilder(PhpredisAdapter::class)
             ->disableOriginalConstructor()
             ->setMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();

--- a/tests/Adapter/RedisAdapterTest.php
+++ b/tests/Adapter/RedisAdapterTest.php
@@ -35,7 +35,7 @@ class RedisAdapterTest extends TestCase
     {
         $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['get', 'set'])
+            ->addMethods(['get', 'set'])
             ->getMock();
 
         $clientMock->expects($this->once())
@@ -64,7 +64,7 @@ class RedisAdapterTest extends TestCase
     {
         $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['get', 'set'])
+            ->addMethods(['get', 'set'])
             ->getMock();
 
         $clientMock->expects($this->once())
@@ -97,7 +97,7 @@ class RedisAdapterTest extends TestCase
 
         $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['get', 'exists'])
+            ->addMethods(['get', 'exists'])
             ->getMock();
 
         $clientMock->expects($this->once())
@@ -121,7 +121,7 @@ class RedisAdapterTest extends TestCase
     {
         $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['exists'])
+            ->addMethods(['exists'])
             ->getMock();
 
         $clientMock->expects($this->once())
@@ -142,7 +142,7 @@ class RedisAdapterTest extends TestCase
     {
         $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['exists'])
+            ->addMethods(['exists'])
             ->getMock();
 
         $clientMock->expects($this->once())
@@ -163,7 +163,7 @@ class RedisAdapterTest extends TestCase
     {
         $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['mget'])
+            ->addMethods(['mget'])
             ->getMock();
 
         $clientMock->expects($this->once())
@@ -184,7 +184,7 @@ class RedisAdapterTest extends TestCase
     {
         $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['mget'])
+            ->addMethods(['mget'])
             ->getMock();
 
         $clientMock->expects($this->once())
@@ -205,7 +205,7 @@ class RedisAdapterTest extends TestCase
     {
         $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['pipeline'])
+            ->onlyMethods(['pipeline'])
             ->getMock();
 
         $clientMock->expects($this->once())
@@ -226,7 +226,7 @@ class RedisAdapterTest extends TestCase
     {
         $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['del'])
+            ->addMethods(['del'])
             ->getMock();
 
         $clientMock->expects($this->once())
@@ -247,7 +247,7 @@ class RedisAdapterTest extends TestCase
     {
         $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['del'])
+            ->addMethods(['del'])
             ->getMock();
 
         $clientMock->expects($this->once())
@@ -268,7 +268,7 @@ class RedisAdapterTest extends TestCase
     {
         $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['del'])
+            ->addMethods(['del'])
             ->getMock();
 
         $clientMock->expects($this->once())
@@ -289,7 +289,7 @@ class RedisAdapterTest extends TestCase
     {
         $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['del'])
+            ->addMethods(['del'])
             ->getMock();
 
         $clientMock->expects($this->once())
@@ -310,7 +310,7 @@ class RedisAdapterTest extends TestCase
     {
         $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['flushAll'])
+            ->addMethods(['flushAll'])
             ->getMock();
 
         $clientMock->expects($this->once())
@@ -333,7 +333,7 @@ class RedisAdapterTest extends TestCase
     {
         return $this->getMockBuilder(RedisAdapter::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setNamespace'])
+            ->onlyMethods(['setNamespace'])
             ->getMock();
     }
 }

--- a/tests/Adapter/RedisAdapterTest.php
+++ b/tests/Adapter/RedisAdapterTest.php
@@ -5,15 +5,18 @@ declare(strict_types=1);
 namespace Linio\Component\Cache\Adapter;
 
 use PHPUnit\Framework\TestCase;
+use Predis\Client;
+use Predis\Command\Processor\KeyPrefixProcessor;
+use Predis\Configuration\Options;
 use Predis\Response\Status;
 
 class RedisAdapterTest extends TestCase
 {
     public function testIsSettingNamespace(): void
     {
-        $clientMock = $this->prophesize('Predis\Client');
-        $processorMock = $this->prophesize('Predis\Command\Processor\KeyPrefixProcessor');
-        $optionsMock = $this->prophesize('Predis\Configuration\Options');
+        $clientMock = $this->prophesize(Client::class);
+        $processorMock = $this->prophesize(KeyPrefixProcessor::class);
+        $optionsMock = $this->prophesize(Options::class);
         $optionsMock->prefix = $processorMock;
 
         $redisAdapter = new RedisAdapter();
@@ -30,7 +33,7 @@ class RedisAdapterTest extends TestCase
 
     public function testIsSettingAndGettingWithTtl(): void
     {
-        $clientMock = $this->getMockBuilder('\Predis\Client')
+        $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->setMethods(['get', 'set'])
             ->getMock();
@@ -59,7 +62,7 @@ class RedisAdapterTest extends TestCase
 
     public function testIsSettingAndGettingWithoutTtl(): void
     {
-        $clientMock = $this->getMockBuilder('\Predis\Client')
+        $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->setMethods(['get', 'set'])
             ->getMock();
@@ -92,7 +95,7 @@ class RedisAdapterTest extends TestCase
     {
         $this->expectException(\Linio\Component\Cache\Exception\KeyNotFoundException::class);
 
-        $clientMock = $this->getMockBuilder('\Predis\Client')
+        $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->setMethods(['get', 'exists'])
             ->getMock();
@@ -116,7 +119,7 @@ class RedisAdapterTest extends TestCase
 
     public function testIsFindingKey(): void
     {
-        $clientMock = $this->getMockBuilder('\Predis\Client')
+        $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->setMethods(['exists'])
             ->getMock();
@@ -137,7 +140,7 @@ class RedisAdapterTest extends TestCase
 
     public function testIsNotFindingKey(): void
     {
-        $clientMock = $this->getMockBuilder('\Predis\Client')
+        $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->setMethods(['exists'])
             ->getMock();
@@ -158,7 +161,7 @@ class RedisAdapterTest extends TestCase
 
     public function testIsGettingMultipleKeys(): void
     {
-        $clientMock = $this->getMockBuilder('\Predis\Client')
+        $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->setMethods(['mget'])
             ->getMock();
@@ -179,7 +182,7 @@ class RedisAdapterTest extends TestCase
 
     public function testIsGettingMultipleKeysWithInvalidKeys(): void
     {
-        $clientMock = $this->getMockBuilder('\Predis\Client')
+        $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->setMethods(['mget'])
             ->getMock();
@@ -200,7 +203,7 @@ class RedisAdapterTest extends TestCase
 
     public function testIsSettingMultipleKeys(): void
     {
-        $clientMock = $this->getMockBuilder('\Predis\Client')
+        $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->setMethods(['pipeline'])
             ->getMock();
@@ -221,7 +224,7 @@ class RedisAdapterTest extends TestCase
 
     public function testIsDeletingKey(): void
     {
-        $clientMock = $this->getMockBuilder('\Predis\Client')
+        $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->setMethods(['del'])
             ->getMock();
@@ -242,7 +245,7 @@ class RedisAdapterTest extends TestCase
 
     public function testIsDeletingMultipleKeys(): void
     {
-        $clientMock = $this->getMockBuilder('\Predis\Client')
+        $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->setMethods(['del'])
             ->getMock();
@@ -263,7 +266,7 @@ class RedisAdapterTest extends TestCase
 
     public function testIsDeletingNonexistentKey(): void
     {
-        $clientMock = $this->getMockBuilder('\Predis\Client')
+        $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->setMethods(['del'])
             ->getMock();
@@ -284,7 +287,7 @@ class RedisAdapterTest extends TestCase
 
     public function testIsDeletingNonexistentMultipleKeys(): void
     {
-        $clientMock = $this->getMockBuilder('\Predis\Client')
+        $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->setMethods(['del'])
             ->getMock();
@@ -305,7 +308,7 @@ class RedisAdapterTest extends TestCase
 
     public function testIsFlushingData(): void
     {
-        $clientMock = $this->getMockBuilder('\Predis\Client')
+        $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->setMethods(['flushAll'])
             ->getMock();
@@ -328,7 +331,7 @@ class RedisAdapterTest extends TestCase
      */
     private function getRedisAdapterMock()
     {
-        return $this->getMockBuilder('Linio\Component\Cache\Adapter\RedisAdapter')
+        return $this->getMockBuilder(RedisAdapter::class)
             ->disableOriginalConstructor()
             ->setMethods(['setNamespace'])
             ->getMock();

--- a/tests/Adapter/WincacheAdapterTest.php
+++ b/tests/Adapter/WincacheAdapterTest.php
@@ -13,7 +13,7 @@ class WincacheAdapterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->adapter = $this->getMockBuilder('Linio\Component\Cache\Adapter\WinCacheAdapter')
+        $this->adapter = $this->getMockBuilder(WincacheAdapter::class)
             ->disableOriginalConstructor()
             ->setMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();

--- a/tests/Adapter/WincacheAdapterTest.php
+++ b/tests/Adapter/WincacheAdapterTest.php
@@ -15,7 +15,7 @@ class WincacheAdapterTest extends TestCase
     {
         $this->adapter = $this->getMockBuilder(WincacheAdapter::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
+            ->onlyMethods(['setNamespace', 'set', 'get', 'delete', 'contains', 'flush', 'getMulti', 'setMulti', 'deleteMulti'])
             ->getMock();
         $this->adapter->setNamespace('mx');
     }

--- a/tests/CacheServiceTest.php
+++ b/tests/CacheServiceTest.php
@@ -50,7 +50,7 @@ class CacheServiceTest extends TestCase
             ]
         );
 
-        $this->assertInstanceOf('\Linio\Component\Cache\CacheService', $cacheService);
+        $this->assertInstanceOf(CacheService::class, $cacheService);
     }
 
     public function testIsValidatingServiceConfiguration(): void


### PR DESCRIPTION
- setMethods on Mocks is deprecated on phpunit. It was replaced by either onlyMethods or addMethods accordingly 
- remove unused variables on unit tests.
- Use imports and fully qualified class names, and avoid using strings to specify class names