### PR TITLE
feat: add ttl parameter to Cache::set

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,14 @@ $app['cache.service']->set('foo', 'bar');
      /**
      * @param string $key
      * @param string $value
+     * @param ?int $ttl Time To Live; store value in the cache for ttl seconds.
+     * This ttl overwrites the configuration ttl of the adapter
      * @return bool
      */
-    public function set($key, $value);
+    public function set(string $key, $value, ?int $ttl = null);
 
     $adapter->set('foo', 'bar');
+    $adapter->set('foo', 'bar', 60); // store bar in the cache for 60 seconds
 
 ```
 

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -22,7 +22,7 @@ interface AdapterInterface
     /**
      * @param mixed $value
      */
-    public function set(string $key, $value): bool;
+    public function set(string $key, $value, ?int $ttl = null): bool;
 
     public function setMulti(array $data): bool;
 

--- a/src/Adapter/ApcAdapter.php
+++ b/src/Adapter/ApcAdapter.php
@@ -53,9 +53,9 @@ class ApcAdapter extends AbstractAdapter implements AdapterInterface
     /**
      * @param mixed $value
      */
-    public function set(string $key, $value): bool
+    public function set(string $key, $value, ?int $ttl = null): bool
     {
-        return apc_store($this->addNamespaceToKey($key), $value, $this->ttl);
+        return apc_store($this->addNamespaceToKey($key), $value, $ttl ?? $this->ttl);
     }
 
     public function setMulti(array $data): bool

--- a/src/Adapter/ApcuAdapter.php
+++ b/src/Adapter/ApcuAdapter.php
@@ -47,9 +47,9 @@ class ApcuAdapter extends AbstractAdapter implements AdapterInterface
     /**
      * @param mixed $value
      */
-    public function set(string $key, $value): bool
+    public function set(string $key, $value, ?int $ttl = null): bool
     {
-        return apcu_store($this->addNamespaceToKey($key), $value, $this->ttl);
+        return apcu_store($this->addNamespaceToKey($key), $value, $ttl ?? $this->ttl);
     }
 
     public function setMulti(array $data): bool

--- a/src/Adapter/ArrayAdapter.php
+++ b/src/Adapter/ArrayAdapter.php
@@ -44,8 +44,9 @@ class ArrayAdapter extends AbstractAdapter implements AdapterInterface
 
     /**
      * @param mixed $value
+     * @param ?int $ttl it does not have effect here
      */
-    public function set(string $key, $value): bool
+    public function set(string $key, $value, ?int $ttl = null): bool
     {
         $this->cacheData[$this->addNamespaceToKey($key)] = $value;
 

--- a/src/Adapter/MemcachedAdapter.php
+++ b/src/Adapter/MemcachedAdapter.php
@@ -78,9 +78,9 @@ class MemcachedAdapter extends AbstractAdapter implements AdapterInterface
     /**
      * @param mixed $value
      */
-    public function set(string $key, $value): bool
+    public function set(string $key, $value, ?int $ttl = null): bool
     {
-        return $this->memcached->set($key, $value, $this->ttl);
+        return $this->memcached->set($key, $value, $ttl ?? $this->ttl);
     }
 
     public function setMulti(array $data): bool

--- a/src/Adapter/MysqlAdapter.php
+++ b/src/Adapter/MysqlAdapter.php
@@ -72,8 +72,9 @@ class MysqlAdapter extends AbstractAdapter implements AdapterInterface
 
     /**
      * @param mixed $value
+     * @param ?int $ttl it does not have effect here
      */
-    public function set(string $key, $value): bool
+    public function set(string $key, $value, ?int $ttl = null): bool
     {
         $sql = sprintf('INSERT INTO `%s` (`key`, `value`) VALUES(:key, :value) ON DUPLICATE KEY UPDATE `value` = VALUES(`value`)', $this->tableName);
 

--- a/src/Adapter/PhpredisAdapter.php
+++ b/src/Adapter/PhpredisAdapter.php
@@ -67,13 +67,15 @@ class PhpredisAdapter extends AbstractAdapter implements AdapterInterface
     /**
      * @param mixed $value
      */
-    public function set(string $key, $value): bool
+    public function set(string $key, $value, ?int $ttl = null): bool
     {
-        if ($this->ttl === null) {
+        $customTtl = $ttl ?? $this->ttl;
+
+        if ($customTtl === null) {
             $result = $this->getClient()->set($key, $value);
         } else {
             /** @var string $value */
-            $result = $this->getClient()->setex($key, $this->ttl, $value);
+            $result = $this->getClient()->setex($key, $customTtl, $value);
         }
 
         return (bool) $result;

--- a/src/Adapter/RedisAdapter.php
+++ b/src/Adapter/RedisAdapter.php
@@ -68,14 +68,14 @@ class RedisAdapter extends AbstractAdapter implements AdapterInterface
      */
     public function set(string $key, $value, ?int $ttl = null): bool
     {
-        $customTll = $ttl ?? $this->ttl;
+        $customTtl = $ttl ?? $this->ttl;
 
-        if ($customTll == 0) {
+        if ($customTtl == 0) {
             /** @var Status $result */
             $result = $this->getClient()->set($key, $value);
         } else {
             /** @var Status $result */
-            $result = $this->getClient()->set($key, $value, static::EXPIRE_RESOLUTION_EX, $customTll);
+            $result = $this->getClient()->set($key, $value, static::EXPIRE_RESOLUTION_EX, $customTtl);
         }
 
         return $result->getPayload() == 'OK';

--- a/src/Adapter/RedisAdapter.php
+++ b/src/Adapter/RedisAdapter.php
@@ -66,14 +66,16 @@ class RedisAdapter extends AbstractAdapter implements AdapterInterface
     /**
      * @param mixed $value
      */
-    public function set(string $key, $value): bool
+    public function set(string $key, $value, ?int $ttl = null): bool
     {
-        if ($this->ttl == 0) {
+        $customTll = $ttl ?? $this->ttl;
+
+        if ($customTll == 0) {
             /** @var Status $result */
             $result = $this->getClient()->set($key, $value);
         } else {
             /** @var Status $result */
-            $result = $this->getClient()->set($key, $value, static::EXPIRE_RESOLUTION_EX, $this->ttl);
+            $result = $this->getClient()->set($key, $value, static::EXPIRE_RESOLUTION_EX, $customTll);
         }
 
         return $result->getPayload() == 'OK';

--- a/src/Adapter/WincacheAdapter.php
+++ b/src/Adapter/WincacheAdapter.php
@@ -52,9 +52,9 @@ class WincacheAdapter extends AbstractAdapter implements AdapterInterface
     /**
      * @param mixed $value
      */
-    public function set(string $key, $value): bool
+    public function set(string $key, $value, ?int $ttl = null): bool
     {
-        return wincache_ucache_set($this->addNamespaceToKey($key), $value, $this->ttl);
+        return wincache_ucache_set($this->addNamespaceToKey($key), $value, $ttl ?? $this->ttl);
     }
 
     public function setMulti(array $data): bool

--- a/src/CacheService.php
+++ b/src/CacheService.php
@@ -153,18 +153,19 @@ class CacheService
 
     /**
      * @param mixed $value
+     * @param int $ttl [optional] Time To Live; store value in the cache for ttl seconds.
      */
-    public function set(string $key, $value): bool
+    public function set(string $key, $value, ?int $ttl = null): bool
     {
         $value = $this->encoder->encode($value);
 
-        return $this->recursiveSet($key, $value);
+        return $this->recursiveSet($key, $value, null, $ttl);
     }
 
     /**
      * @param mixed $value
      */
-    protected function recursiveSet(string $key, $value, int $level = null): bool
+    protected function recursiveSet(string $key, $value, int $level = null, ?int $ttl = null): bool
     {
         $adapterStack = $this->getAdapterStack();
 
@@ -173,7 +174,7 @@ class CacheService
         }
 
         $adapter = $adapterStack[$level];
-        $result = $adapter->set($key, $value);
+        $result = $adapter->set($key, $value, $ttl);
 
         if ($level == 0) {
             return true;
@@ -183,7 +184,7 @@ class CacheService
             return false;
         }
 
-        return $this->recursiveSet($key, $value, $level - 1);
+        return $this->recursiveSet($key, $value, $level - 1, $ttl);
     }
 
     public function setMulti(array $data): bool

--- a/src/CacheService.php
+++ b/src/CacheService.php
@@ -153,7 +153,7 @@ class CacheService
 
     /**
      * @param mixed $value
-     * @param int $ttl [optional] Time To Live; store value in the cache for ttl seconds.
+     * @param int $ttl [optional] Time To Live; store value in the cache for ttl seconds
      */
     public function set(string $key, $value, ?int $ttl = null): bool
     {

--- a/tests/Adapter/ApcAdapterTest.php
+++ b/tests/Adapter/ApcAdapterTest.php
@@ -39,6 +39,25 @@ class ApcAdapterTest extends TestCase
         $this->assertEquals('bar', $actual);
     }
 
+    public function testIsSettingWithCustomTtlAndGetting(): void
+    {
+        $this->adapter->expects($this->once())
+            ->method('set')
+            ->with($this->equalTo('foo'), $this->equalTo('bar'), 20)
+            ->willReturn(true);
+
+        $this->adapter->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('foo'))
+            ->willReturn('bar');
+
+        $setResult = $this->adapter->set('foo', 'bar', 20);
+        $actual = $this->adapter->get('foo');
+
+        $this->assertTrue($setResult);
+        $this->assertEquals('bar', $actual);
+    }
+
     public function testIsGettingNonexistentKey(): void
     {
         $this->adapter->expects($this->once())

--- a/tests/Adapter/ApcuAdapterTest.php
+++ b/tests/Adapter/ApcuAdapterTest.php
@@ -39,6 +39,25 @@ class ApcuAdapterTest extends TestCase
         $this->assertEquals('bar', $actual);
     }
 
+    public function testIsSettingWithCustomTtlAndGetting(): void
+    {
+        $this->adapter->expects($this->once())
+            ->method('set')
+            ->with($this->equalTo('foo'), $this->equalTo('bar'), 20)
+            ->willReturn(true);
+
+        $this->adapter->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('foo'))
+            ->willReturn('bar');
+
+        $setResult = $this->adapter->set('foo', 'bar', 20);
+        $actual = $this->adapter->get('foo');
+
+        $this->assertTrue($setResult);
+        $this->assertEquals('bar', $actual);
+    }
+
     public function testIsGettingNonexistentKey(): void
     {
         $this->adapter->expects($this->once())

--- a/tests/Adapter/MemcachedAdapterTest.php
+++ b/tests/Adapter/MemcachedAdapterTest.php
@@ -42,6 +42,25 @@ class MemcachedAdapterTest extends TestCase
         $this->assertEquals('bar', $actual);
     }
 
+    public function testIsSettingWithCustomTtlAndGetting(): void
+    {
+        $this->adapter->expects($this->once())
+            ->method('set')
+            ->with($this->equalTo('foo'), $this->equalTo('bar'), 30)
+            ->willReturn(true);
+
+        $this->adapter->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('foo'))
+            ->willReturn('bar');
+
+        $setResult = $this->adapter->set('foo', 'bar', 30);
+        $actual = $this->adapter->get('foo');
+
+        $this->assertTrue($setResult);
+        $this->assertEquals('bar', $actual);
+    }
+
     public function testIsGettingNonexistentKey(): void
     {
         $this->adapter->expects($this->once())

--- a/tests/Adapter/PhpredisAdapterTest.php
+++ b/tests/Adapter/PhpredisAdapterTest.php
@@ -24,7 +24,7 @@ class PhpredisAdapterTest extends TestCase
     {
         $this->adapter->expects($this->once())
             ->method('set')
-            ->with($this->equalTo('foo'))
+            ->with($this->equalTo('foo'), $this->equalTo('bar'))
             ->willReturn(true);
 
         $this->adapter->expects($this->once())
@@ -33,6 +33,25 @@ class PhpredisAdapterTest extends TestCase
             ->willReturn('bar');
 
         $setResult = $this->adapter->set('foo', 'bar');
+        $actual = $this->adapter->get('foo');
+
+        $this->assertTrue($setResult);
+        $this->assertEquals('bar', $actual);
+    }
+
+    public function testIsSettingWithCustomTtlAndGetting(): void
+    {
+        $this->adapter->expects($this->once())
+            ->method('set')
+            ->with($this->equalTo('foo'), $this->equalTo('bar'), 60)
+            ->willReturn(true);
+
+        $this->adapter->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('foo'))
+            ->willReturn('bar');
+
+        $setResult = $this->adapter->set('foo', 'bar', 60);
         $actual = $this->adapter->get('foo');
 
         $this->assertTrue($setResult);

--- a/tests/Adapter/RedisAdapterTest.php
+++ b/tests/Adapter/RedisAdapterTest.php
@@ -60,6 +60,35 @@ class RedisAdapterTest extends TestCase
         $this->assertEquals('bar', $actual);
     }
 
+    public function testIsSettingAndGettingWithCustomTtl(): void
+    {
+        $clientMock = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['get', 'set'])
+            ->getMock();
+
+        $clientMock->expects($this->once())
+            ->method('set')
+            ->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(RedisAdapter::EXPIRE_RESOLUTION_EX), 30)
+            ->willReturn(new Status('OK'));
+
+        $clientMock->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('foo'))
+            ->willReturn('bar');
+
+        $adapter = $this->getRedisAdapterMock();
+        $adapter->setClient($clientMock);
+        $adapter->setNamespace('mx');
+        $adapter->setTtl(60);
+
+        $setResult = $adapter->set('foo', 'bar', 30);
+        $actual = $adapter->get('foo');
+
+        $this->assertTrue($setResult);
+        $this->assertEquals('bar', $actual);
+    }
+
     public function testIsSettingAndGettingWithoutTtl(): void
     {
         $clientMock = $this->getMockBuilder(Client::class)

--- a/tests/Adapter/WincacheAdapterTest.php
+++ b/tests/Adapter/WincacheAdapterTest.php
@@ -39,6 +39,25 @@ class WincacheAdapterTest extends TestCase
         $this->assertEquals('bar', $actual);
     }
 
+    public function testIsSettingWithCustomTtlAndGetting(): void
+    {
+        $this->adapter->expects($this->once())
+            ->method('set')
+            ->with($this->equalTo('foo'), $this->equalTo('bar'), 20)
+            ->willReturn(true);
+
+        $this->adapter->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('foo'))
+            ->willReturn('bar');
+
+        $setResult = $this->adapter->set('foo', 'bar', 20);
+        $actual = $this->adapter->get('foo');
+
+        $this->assertTrue($setResult);
+        $this->assertEquals('bar', $actual);
+    }
+
     public function testIsGettingNonexistentKey(): void
     {
         $this->adapter->expects($this->once())


### PR DESCRIPTION
This allows us to overwrite the time to live defined on the global configuration of each adapter.